### PR TITLE
refactor(scroll): extract scroll logic into custom hook

### DIFF
--- a/app/admin/suppliers/page.tsx
+++ b/app/admin/suppliers/page.tsx
@@ -15,6 +15,7 @@ import DeleteSupplier from "./DeleteSupplier";
 import { Mutations } from "@/lib/Constants";
 import { Input } from "@/components/ui/input";
 import PageTitle from "@/components/Layout/Admin/PageTitle";
+import useScroll from "@/hooks/scroll";
 
 const fetcher = async () => {
   try {
@@ -37,6 +38,7 @@ const Supplier = () => {
     isLoading,
   } = useSWR<Supplier[]>(Mutations.SUPPLIERS.FETCH, fetcher);
 
+  const isScrolled = useScroll();
   const [search, setSearch] = React.useState("");
   const [filteredSuppliers, setFilteredSuppliers] = React.useState<Supplier[]>(
     []
@@ -86,7 +88,11 @@ const Supplier = () => {
           />
         </div>
       </PageTitle>
-      <div className="flex flex-col justify-center mt-5 dark:bg-[#131315] bg-[#f3f3f3] rounded-2xl dark:text-white text-black mb-0 sm:mb-32">
+      <div
+        className={`flex flex-col justify-center ${
+          isScrolled ? "mt-28 sm:mt-32" : "mt-5"
+        } dark:bg-[#131315] bg-[#f3f3f3] rounded-2xl dark:text-white text-black mb-0 sm:mb-32`}
+      >
         <Table className="w-full">
           <TableHeader className="">
             <TableRow>

--- a/components/Layout/Admin/PageTitle.tsx
+++ b/components/Layout/Admin/PageTitle.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import useScroll from "@/hooks/scroll";
 
 const PageTitle = ({
   title,
@@ -9,16 +10,8 @@ const PageTitle = ({
   subText: string;
   children: React.ReactNode;
 }) => {
-  const [isScrolled, setIsScrolled] = React.useState(false);
+  const isScrolled = useScroll();
 
-  React.useEffect(() => {
-    const handleScroll = () => {
-      setIsScrolled(window.scrollY > 50);
-    };
-
-    window.addEventListener("scroll", handleScroll);
-    return () => window.removeEventListener("scroll", handleScroll);
-  }, []);
   return (
     <div
       className={`bg-white dark:bg-[#0A0A0A] ${

--- a/hooks/scroll.tsx
+++ b/hooks/scroll.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+const useScroll = (threshold = 50) => {
+  const [isScrolled, setIsScrolled] = React.useState(false);
+
+  React.useEffect(() => {
+    const handleScroll = () => {
+      setIsScrolled(window.scrollY > threshold);
+    };
+
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, [threshold]);
+
+  return isScrolled;
+};
+
+export default useScroll;


### PR DESCRIPTION
Move scroll detection logic from components to a reusable `useScroll` hook to improve code maintainability and reduce duplication. The hook is now used in `PageTitle` and `Supplier` components.